### PR TITLE
Fix gettext dependency in panel Dockerfile

### DIFF
--- a/installer/panel/Dockerfile
+++ b/installer/panel/Dockerfile
@@ -3,7 +3,36 @@ FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 SHELL ["/bin/bash","-o","pipefail","-c"]
 
-RUN apt-get update && apt-get install -y --no-install-recommends     tzdata ca-certificates curl wget gnupg lsb-release gettext-base     supervisor rsyslog cron logrotate     nginx php-fpm php-cli php-curl php-xml php-mysql php-mbstring php-zip php-intl php-gd php-imap     mariadb-client unzip tar crudini &&     apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+    tzdata \
+    ca-certificates \
+    curl \
+    wget \
+    gnupg \
+    lsb-release \
+    gettext-base \
+    supervisor \
+    rsyslog \
+    cron \
+    logrotate \
+    nginx \
+    php-fpm \
+    php-cli \
+    php-curl \
+    php-xml \
+    php-mysql \
+    php-mbstring \
+    php-zip \
+    php-intl \
+    php-gd \
+    php-imap \
+    mariadb-client \
+    unzip \
+    tar \
+    crudini \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Timezone configurable at runtime; keep default as UTC to avoid surprises
 RUN ln -snf /usr/share/zoneinfo/${TZ:-Etc/UTC} /etc/localtime && echo ${TZ:-Etc/UTC} >/etc/timezone || true
@@ -11,7 +40,6 @@ RUN ln -snf /usr/share/zoneinfo/${TZ:-Etc/UTC} /etc/localtime && echo ${TZ:-Etc/
 # Fetch ISPConfig (rolling stable tarball)
 RUN set -euo pipefail;     URL_S="https://www.ispconfig.org/downloads/ISPConfig-3-stable.tar.gz";     curl -fSL "$URL_S" -o /tmp/ISPConfig.tar.gz &&     mkdir -p /opt && tar -xzf /tmp/ISPConfig.tar.gz -C /opt && rm /tmp/ISPConfig.tar.gz &&     ln -s /opt/ispconfig3_install /opt/ispconfig-installer &&     if [ -d /opt/ispconfig3_install/docs/autoinstall_samples ]; then         cp -a /opt/ispconfig3_install/docs/autoinstall_samples/*.sample /opt/ispconfig3_install/install/ || true ;     fi
 
-# Minimal default site so nginx test succeeds before install writes real vhosts
 # Minimal default site so nginx test succeeds before install writes real vhosts
 
 RUN set -eux; \


### PR DESCRIPTION
## Summary
- ensure the panel image installs the gettext-base package correctly
- reformat the apt-get package list for readability while keeping cleanup steps

## Testing
- not run (Docker CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e63ef2c1388328a13adee22bec4b66